### PR TITLE
Add new grammar rules & adapt naming

### DIFF
--- a/q3/syntaxes/q3.tmLanguage.json
+++ b/q3/syntaxes/q3.tmLanguage.json
@@ -16,10 +16,10 @@
 					"include": "#comments"
 				},
 				{
-					"include": "#variable"
+					"include": "#keywords"
 				},
 				{
-					"include": "#keywords"
+					"include": "#class"
 				},
 				{
 					"include": "#int"
@@ -42,18 +42,15 @@
 			]
 		},
 		"libs": {
-			"patterns": [
+			"patterns":[
 				{
 					"include": "#mc.enums"
-				},
-				{
-					"include": "#mc.events.classes"
 				},
 				{
 					"include": "#quests.functions"
 				}
 			]
-		}, 
+		},
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.q3",
@@ -98,7 +95,12 @@
 			"begin": "([A-Za-z_][\\w$]*)\\s*(\\()",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.q3"
+					"name": "entity.name.function.q3",
+					"patterns": [
+						{
+							"include": "#quests.functions"
+						}
+					]
 				},
 				"2": {
 					"name": "punctuation.definition.parameters.begin.bracket.round.q3"
@@ -124,12 +126,15 @@
 			]
 		},
 		"function-member": {
-			"begin": "(\\$[A-Za-z_][\\w$]*)\\s*(\\()",
+			"begin": "(\\$)([A-Za-z_][\\w$]*)\\s*(\\()",
 			"beginCaptures": {
 				"1": {
-					"name": "variable.other.q3"
+					"name": "keyword.operator.q3"
 				},
 				"2": {
+					"name": "entity.name.function.q3"
+				},
+				"3": {
 					"name": "punctuation.definition.parameters.begin.bracket.round.q3"
 				}
 			},
@@ -142,7 +147,42 @@
 			"name": "meta.function.q3",
 			"patterns": [
 				{
+					"include": "#code"
+				}
+			]
+		},
+		"class": {
+			"begin": "(class!?|enum)?\\s+([A-Z][\\w$]*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.q3"
+				},
+				"2": {
+					"name": "entity.name.class.q3",
+					"patterns": [
+						{
+							"include": "#mc.events.classes"
+						}
+					]
+				},
+				"3": {
+					"name": "punctuation.definition.parameters.begin.bracket.round.q3"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.bracket.round.q3"
+				}
+			},
+			"name": "meta.type.name.q3",
+			"patterns": [
+				{
 					"include": "#constructor-parameters"
+				},
+				{
+					"name": "variable.parameter.q3",
+					"match": "[a-z_]+"
 				},
 				{
 					"include": "#code"
@@ -151,7 +191,7 @@
 		},
 		"member-variables": {
 			"match": "((@)[A-Za-z_$][\\w$]*)",
-			"name": "variable.language.q3"
+			"name": "variable.other.q3"
 		},
 		"constructor-parameters": {
 			"name": "variable.parameter.q3",
@@ -161,7 +201,6 @@
 			"name": "keyword.operator.q3",
 			"match": "(\\$|\\@|\\+|\\-|\\*|\\/|\\%|=|\\+\\=|\\-\\=|\\*\\=|\\/\\=|\\%\\=|<<=|>>=|>>>=|&=|\\|=|\\^=|!|==|\\\"=|\\|\\||&&|\\||&|\\^|~|<|>|<=|>=|=>|!=>|->|>>|>>>|<<|\\?|:|_)"
 		},
-
 		"mc.enums": {
 			"patterns": [{
 				"name": "support.type.mc.q3",

--- a/q3/syntaxes/q3.tmLanguage.json
+++ b/q3/syntaxes/q3.tmLanguage.json
@@ -3,54 +3,61 @@
 	"name": "q3",
 	"patterns": [
 		{
-			"include": "#comments"
+			"include": "#code"
 		},
 		{
-			"include": "#variable"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#Enums"
-		},
-		{
-			"include": "#Q3Functions"
-		},
-		{
-			"include": "#Q3EventClasses"
-		},
-		{
-			"include": "#int"
-		},
-		{
-			"include": "#strings"
+			"include": "#libs"
 		}
-		
 	],
 	"repository": {
+		"code": {
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#variable"
+				},
+				{
+					"include": "#keywords"
+				},
+				{
+					"include": "#int"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#function-member"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#member-variables"
+				},
+				{
+					"include": "#operators"
+				}
+			]
+		},
+		"libs": {
+			"patterns": [
+				{
+					"include": "#mc.enums"
+				},
+				{
+					"include": "#mc.events.classes"
+				},
+				{
+					"include": "#quests.functions"
+				}
+			]
+		}, 
 		"keywords": {
 			"patterns": [{
-				"name": "keyword.control.q3",
-				"match": "\\b(class|enum|extends|if|else|while|do|for|foreach|break|continue|return|throw|sleep|instanceof|wait|key|nf|want|fork|null|true|false|this|ctask|match|case|default|try|catch|finally|static|public|private|protected|const|abstract|final)\\b"
-			}]
-		},
-		"Enums": {
-			"patterns": [{
-				"name": "Enums.q3",
-				"match": "\\b(Achievement|ActiveEffect|AnvilActionType|AttachedFace|Axis|AxolotlType|BarColor|BarFlag|BarStyle|BeeContainerType|BellAttachment|Block|BossBar|Box|catType|ChestAttachement|Color|ComparatorMode|ConsoleSender|DamageCause|DragonPhase|DripleafTilt|DripstoneThickness|Effect|Enchant|Face|FoxType|FurnanceType|GameMode|HeadType|HorseColor|HorseStyle|IllagerSpell|Inventory|ItemFlag|JobType|LlamaType|Loc|LogginLevel|MooshroomType|MouseKey|MushroomBlockType|PaintingType|PandaGene|ParrotType|Particle|Pattern|PatternType|PermissionLevel|PickupPolicy|PlayerJob|PlayerProfile|PotionType|PriveCalculator|QuickFlashEvent|RabbitType|RailShape|RegionFlag|RegionOwnerRole|RegionType|ReloadFilesEvent|RestartServiceEvent|Rotation|Scroll|Sex|SharedBalance|SidebarModule|Skill|SkillType|SlabType|Sound|StairShape|ToolType|TropicalFishPattern|VillagerProfession|WoodType|Item)\\b"
-			}]
-		},
-		"Q3Functions": {
-			"patterns": [{
-				"name": "q3.functions.q3",
-				"match": "\\b(npc|p|ps|region|setSidebarMsg|talk|answer|setDeadline|sleep|online|giveTempItem|giveItem|checkCollab|sendInfo|waitUntilNearby|npc.acceptItem|waitAsync|thenApply|listen|repeat|delay|waitAll|waitAny|nfAll|nfAny|rndOffsetLoc|QResult|makeProgress|talkBetweenNpcs|think|waitUntilFar|tp|setRespawnPoint|setTracker)\\b"
-			}]
-		},
-		"Q3EventClasses": {
-			"patterns": [{
-				"name": "EventClasses.q3",
-				"match": "\\b(AnvilEnchant|BedEnter|BedEnterS|BlockBreak|BlockbreakS|BlockClick|BlockClickS|BlockPlace|BlockPlaceS|BucketEmpty|BucketEmtpyS|BucketFill|BucketFillS|EntityClick|EntityClickS|EntityDamage|EntityDamageS|EntityDeath|EntityDeathS|Event|ItemDrop|ItemDropS|PlayerChat|PlayerChatS|PlayerCraft|PlayerEatS|PlayerEat|PlayerJoin|PlayerPermsChange|PlayerQuit|PlayerTeleport|PlayerTeleportS|ProjectileHit|ProjectileHitS|ScrollUse|ScrollUseS|Tick|TickS)\\b"
+				"name": "keyword.q3",
+				"match": "\\b(class|enum|new|extends|if|else|while|do|for|foreach|break|continue|return|throw|sleep|instanceof|wait|key|nf|want|fork|null|true|false|this|ctask|match|case|default|try|catch|finally|static|public|private|protected|const|abstract|final)\\b"
 			}]
 		},
 		"strings": {
@@ -60,7 +67,11 @@
 			"patterns": [
 				{
 					"name": "constant.character.escape.q3",
-					"match": "\\\\."
+					"match": "(\\\\.|\\@[\\^\\w]+)"
+				},
+				{
+					"name": "constant.rgb-value",
+					"match": "§[abcdefklmnor0-9]{1}"
 				}
 			]
 		},
@@ -79,10 +90,96 @@
 							"name": "comment.line.double-slash.q3"
 						}
 					},
-					"match": "((#).*)$"
+					"match": "((#)[^\\'\\\"\\n].*)$"
 				}
 			]
-		}		
+		},
+		"function-call": {
+			"begin": "([A-Za-z_][\\w$]*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.q3"
+				},
+				"2": {
+					"name": "punctuation.definition.parameters.begin.bracket.round.q3"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.bracket.round.q3"
+				}
+			},
+			"name": "meta.function.q3",
+			"patterns": [
+				{
+					"include": "#constructor-parameters"
+				},
+				{
+					"include": "#code"
+				},
+				{
+					"include": "#libs"
+				}
+			]
+		},
+		"function-member": {
+			"begin": "(\\$[A-Za-z_][\\w$]*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.other.q3"
+				},
+				"2": {
+					"name": "punctuation.definition.parameters.begin.bracket.round.q3"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.bracket.round.q3"
+				}
+			},
+			"name": "meta.function.q3",
+			"patterns": [
+				{
+					"include": "#constructor-parameters"
+				},
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"member-variables": {
+			"match": "((@)[A-Za-z_$][\\w$]*)",
+			"name": "variable.language.q3"
+		},
+		"constructor-parameters": {
+			"name": "variable.parameter.q3",
+			"match": "([A-Za-z]+:)"
+		},
+		"operators": {
+			"name": "keyword.operator.q3",
+			"match": "(\\$|\\@|\\+|\\-|\\*|\\/|\\%|=|\\+\\=|\\-\\=|\\*\\=|\\/\\=|\\%\\=|<<=|>>=|>>>=|&=|\\|=|\\^=|!|==|\\\"=|\\|\\||&&|\\||&|\\^|~|<|>|<=|>=|=>|!=>|->|>>|>>>|<<|\\?|:|_)"
+		},
+
+		"mc.enums": {
+			"patterns": [{
+				"name": "support.type.mc.q3",
+				"match": "\\b(M|Achievement|ActiveEffect|AnvilActionType|AttachedFace|Axis|AxolotlType|BarColor|BarFlag|BarStyle|BeeContainerType|BellAttachment|Block|BossBar|Box|catType|ChestAttachement|Color|ComparatorMode|ConsoleSender|DamageCause|DragonPhase|DripleafTilt|DripstoneThickness|Effect|Enchant|Face|FoxType|FurnanceType|GameMode|HeadType|HorseColor|HorseStyle|IllagerSpell|Inventory|ItemFlag|JobType|LlamaType|Loc|LogginLevel|MooshroomType|MouseKey|MushroomBlockType|PaintingType|PandaGene|ParrotType|Particle|Pattern|PatternType|PermissionLevel|PickupPolicy|PlayerJob|PlayerProfile|PotionType|PriveCalculator|QuickFlashEvent|RabbitType|RailShape|RegionFlag|RegionOwnerRole|RegionType|ReloadFilesEvent|RestartServiceEvent|Rotation|Scroll|Sex|SharedBalance|SidebarModule|Skill|SkillType|SlabType|Sound|StairShape|ToolType|TropicalFishPattern|VillagerProfession|WoodType|Item)\\b"
+			}]
+		},
+		"quests.functions": {
+			"patterns": [{
+				"name": "support.function.quests.q3",
+				"match": "\\b(npc|p|ps|region|setSidebarMsg|talk|answer|setDeadline|sleep|online|giveTempItem|giveItem|checkCollab|sendInfo|waitUntilNearby|npc.acceptItem|waitAsync|thenApply|listen|repeat|delay|waitAll|waitAny|nfAll|nfAny|rndOffsetLoc|QResult|makeProgress|talkBetweenNpcs|think|waitUntilFar|tp|setRespawnPoint|setTracker|toLoc|toBlock)\\b"
+			}]
+		},
+		"mc.events.classes": {
+			"patterns": [{
+				"name": "support.class.mc.events.q3",
+				"match": "\\b(AnvilEnchant|BedEnter|BedEnterS|BlockBreak|BlockbreakS|BlockClick|BlockClickS|BlockPlace|BlockPlaceS|BucketEmpty|BucketEmtpyS|BucketFill|BucketFillS|EntityClick|EntityClickS|EntityDamage|EntityDamageS|EntityDeath|EntityDeathS|Event|ItemDrop|ItemDropS|PlayerChat|PlayerChatS|PlayerCraft|PlayerEatS|PlayerEat|PlayerJoin|PlayerPermsChange|PlayerQuit|PlayerTeleport|PlayerTeleportS|ProjectileHit|ProjectileHitS|ScrollUse|ScrollUseS|Tick|TickS)\\b"
+			}]
+		}
 	},
 	"scopeName": "source.q3"
 }

--- a/q3/themes/q3-color-theme.json
+++ b/q3/themes/q3-color-theme.json
@@ -2,7 +2,7 @@
 	"name": "q3",
 	"type": "dark",
 	"colors": {
-		"editor.background": "#1d1d1d",
+		"editor.background": "#282c34",
 		"editor.foreground": "#ffffff",
 		"activityBarBadge.background": "#007acc",
 		"sideBarTitle.foreground": "#bbbbbb"
@@ -26,7 +26,7 @@
 				"string constant.other.placeholder"
 			],
 			"settings": {
-				"foreground": "#EEFFFF"
+				"foreground": "#a7ffff"
 			}
 		},
 		{
@@ -54,6 +54,7 @@
 				"keyword",
 				"storage.type",
 				"storage.modifier"
+			
 			],
 			"settings": {
 				"foreground": "#C792EA"
@@ -73,7 +74,7 @@
 				"punctuation.definition.tag.end.html",
 				"punctuation.section.embedded",
 				"keyword.other.template",
-				"keyword.other.substitution"
+				"keyword.other.substitution",
 			],
 			"settings": {
 				"foreground": "#eb7262"
@@ -94,7 +95,7 @@
 			"name": "Function, Special Method",
 			"scope": [
 				"entity.name.function",
-				"meta.function-call",
+				"meta.function",
 				"variable.function",
 				"support.function",
 				"keyword.other.special-method"
@@ -106,7 +107,9 @@
 		{
 			"name": "Block Level Variables",
 			"scope": [
-				"meta.block variable.other"
+				"meta.block variable.other",
+				"variable.other",
+				"meta.block"
 			],
 			"settings": {
 				"foreground": "#f07178"
@@ -628,7 +631,7 @@
 		{
 			"name": "Q3Functions",
 			"scope": [
-				"q3.functions"
+				"support.function.quests.q3"
 			],
 			"settings": {
 				"foreground": "#fde79c"
@@ -637,7 +640,7 @@
 		{
 			"name": "EventClasses",
 			"scope": [
-				"EventClasses"
+				"support.class.mc.events.q3"
 			],
 			"settings": {
 				"foreground": "#ffbb00"
@@ -646,13 +649,12 @@
 		{
 			"name": "Enums",
 			"scope": [
-				"Enums"
+				"support.type.mc.q3"
 			],
 			"settings": {
 				"foreground": "#e1adfa"
 			}
 			
 		}
-		
 	]
 }

--- a/q3/themes/q3-color-theme.json
+++ b/q3/themes/q3-color-theme.json
@@ -182,31 +182,6 @@
 			}
 		},
 		{
-			"name": "CSS Class and Support",
-			"scope": [
-				"source.css support.type.property-name",
-				"source.sass support.type.property-name",
-				"source.scss support.type.property-name",
-				"source.less support.type.property-name",
-				"source.stylus support.type.property-name",
-				"source.postcss support.type.property-name"
-			],
-			"settings": {
-				"foreground": "#B2CCD6"
-			}
-		},
-		{
-			"name": "Sub-methods",
-			"scope": [
-				"entity.name.module.js",
-				"variable.import.parameter.js",
-				"variable.other.class.js"
-			],
-			"settings": {
-				"foreground": "#FF5370"
-			}
-		},
-		{
 			"name": "Language methods",
 			"scope": [
 				"variable.language"
@@ -214,26 +189,6 @@
 			"settings": {
 				"fontStyle": "italic",
 				"foreground": "#FF5370"
-			}
-		},
-		{
-			"name": "entity.name.method.js",
-			"scope": [
-				"entity.name.method.js"
-			],
-			"settings": {
-				"fontStyle": "italic",
-				"foreground": "#82AAFF"
-			}
-		},
-		{
-			"name": "meta.method.js",
-			"scope": [
-				"meta.class-method.js entity.name.function.js",
-				"variable.function.constructor"
-			],
-			"settings": {
-				"foreground": "#82AAFF"
 			}
 		},
 		{
@@ -246,59 +201,12 @@
 			}
 		},
 		{
-			"name": "HTML Attributes",
-			"scope": [
-				"text.html.basic entity.other.attribute-name.html",
-				"text.html.basic entity.other.attribute-name"
-			],
-			"settings": {
-				"fontStyle": "italic",
-				"foreground": "#FFCB6B"
-			}
-		},
-		{
-			"name": "CSS Classes",
-			"scope": [
-				"entity.other.attribute-name.class"
-			],
-			"settings": {
-				"foreground": "#FFCB6B"
-			}
-		},
-		{
 			"name": "CSS ID's",
 			"scope": [
 				"source.sass keyword.control"
 			],
 			"settings": {
 				"foreground": "#82AAFF"
-			}
-		},
-		{
-			"name": "Inserted",
-			"scope": [
-				"markup.inserted"
-			],
-			"settings": {
-				"foreground": "#C3E88D"
-			}
-		},
-		{
-			"name": "Deleted",
-			"scope": [
-				"markup.deleted"
-			],
-			"settings": {
-				"foreground": "#FF5370"
-			}
-		},
-		{
-			"name": "Changed",
-			"scope": [
-				"markup.changed"
-			],
-			"settings": {
-				"foreground": "#C792EA"
 			}
 		},
 		{
@@ -654,7 +562,16 @@
 			"settings": {
 				"foreground": "#e1adfa"
 			}
-			
-		}
+		},
+		{
+			"name": "Entity Name Class,entity Name Type Class",
+			"scope": [
+			  "entity.name.class",
+			  "entity.name.type.class"
+			],
+			"settings": {
+			  "foreground": "#E5C07B"
+			}
+		  },
 	]
 }


### PR DESCRIPTION
language features added:
- functions -> lowercase first letter + ()
- classes -> uppercase first letter + ()
- operator highlighting
- constructor parameters -> Foo(**e**: bar, **allow**: false)
- member variables, prefixed with '@'
- variables within strings, denoted with '@'
- color codes within strings, denoted with '§'
- "new" keyword for anonymous classes
- highlight library functions/classes/variables 

still todo:
- add natlib/stdlib types
- add missing mc lib types

I tried to adapt the rule naming to standard pattern, so other themes recognize the grammar too. I like to use the "One Dark" theme:
![Screenshot_20230128_200153](https://user-images.githubusercontent.com/77941187/215286113-4426569c-344d-406d-9e0b-a1553afa0d63.png)